### PR TITLE
Fix need to regenerate connections

### DIFF
--- a/Assets/Scripts/ArtGen/ArtStyles/Default.cs
+++ b/Assets/Scripts/ArtGen/ArtStyles/Default.cs
@@ -51,11 +51,6 @@ public class DefaultArtStyle : ArtStyle
             m.ClearTriangles();
         }
 
-        foreach (ProvinceMarker pm in provs)
-        {
-            pm.UpdateConnections();
-        }
-
         calc_triangles(m_all_conns, layout);
 
         foreach (ConnectionMarker cm in conns)

--- a/Assets/Scripts/Interactive/ProvinceMarker.cs
+++ b/Assets/Scripts/Interactive/ProvinceMarker.cs
@@ -342,20 +342,6 @@ public class ProvinceMarker: MonoBehaviour
         m_connections.Add(m);
     }
 
-    public void UpdateConnections()
-    {
-        if (IsDummy)
-        {
-            return;
-        }
-
-        foreach (ConnectionMarker m in m_connections)
-        {
-            Vector3 center = get_weighted_center(m.Endpoint1, m.Endpoint2, m.Prov1.Node, m.Prov2.Node);
-            m.gameObject.transform.position = center;
-        }
-    }
-
     public void UpdateLinked()
     {
         if (!IsDummy && LinkedProvinces != null && LinkedProvinces.Any())


### PR DESCRIPTION
Remove UpdateConnections step from regeneration.

This step is not run during original generation and moves the connections breaking code later.